### PR TITLE
Refresh terraform to modern best practices

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -823,29 +823,22 @@ class TerraformGenerator(TemplateGenerator):
         # type: (List[models.Model]) -> Dict[str, Any]
         template = {
             'resource': {},
-            'locals': {},
+            'locals': {
+                'app': self._config.app_name,
+                'stage': self._config.chalice_stage,
+            },
             'terraform': {
-                'required_version': '>= 0.12.26, < 1.4.0',
+                'required_version': '>= 1.5.0, < 2.0.0',
                 'required_providers': {
-                    'aws': {'version': '>= 2, < 5'},
-                    'null': {'version': '>= 2, < 4'}
+                    'aws': {'version': '>= 5, < 6'},
                 }
             },
             'data': {
                 'aws_caller_identity': {'chalice': {}},
                 'aws_partition': {'chalice': {}},
                 'aws_region': {'chalice': {}},
-                'null_data_source': {
-                    'chalice': {
-                        'inputs': {
-                            'app': self._config.app_name,
-                            'stage': self._config.chalice_stage
-                        }
-                    }
-                }
             }
         }
-
         for resource in resources:
             self.dispatch(resource, template)
         return template

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -616,10 +616,8 @@ class TestTerraformTemplate(TemplateTestBase):
                                app_name='myfoo',
                                api_gateway_stage='dev')
         template = self.generate_template(config)
-        assert template['data']['null_data_source']['chalice']['inputs'] == {
-            'app': 'myfoo',
-            'stage': 'dev'
-        }
+        assert template['locals']['app'] == 'myfoo'
+        assert template['locals']['stage'] == 'dev'
 
     def test_can_package_s3_event_handler_sans_filters(self, sample_app):
         @sample_app.on_s3_event(bucket='foo')


### PR DESCRIPTION
* Remove null_data_source, switch to locals
* Bump max AWS version to 6
* Allow a wider terraform version range up to 2.x.x

This is the minimum needed to work with latest tf versions, but I think in the future it would be better to extract these out to config options so people aren't blocked on chalice updates to change these default values.